### PR TITLE
Connections and node matching

### DIFF
--- a/jupyterlab_nodeeditor/__init__.py
+++ b/jupyterlab_nodeeditor/__init__.py
@@ -43,4 +43,3 @@ from .node_editor import (
     OutputSlot,
     SocketCollection,
 )
-from .yggdrasil_support import parse_yggdrasil_yaml

--- a/jupyterlab_nodeeditor/node_editor.py
+++ b/jupyterlab_nodeeditor/node_editor.py
@@ -30,6 +30,12 @@ class InputSlot(ipywidgets.Widget):
         sync=True, **ipywidgets.widget_serialization
     )
 
+    def _ipython_display_(self):
+        display(self.widget())
+
+    def widget(self):
+        return ipywidgets.Label(f"Slot {self.key}: {self.title} ({self.socket_type})")
+
 
 class InputSlotTrait(traitlets.TraitType):
     default_value = None
@@ -123,21 +129,21 @@ class NodeInstanceModel(ipywidgets.Widget):
     def _default_display_element(self):
         def _update_inputs(event):
             input_box.children = [ipywidgets.Label("Inputs")] + [
-                ipywidgets.Label(f"Slot {i+1}: {slot.title} ({slot.key})")
-                for (i, slot) in enumerate(self.inputs)
+                slot.widget() for slot in self.inputs
             ]
 
         def _update_outputs(event):
             output_box.children = [ipywidgets.Label("Outputs")] + [
-                ipywidgets.Label(f"Slot {i+1}: {slot.title} ({slot.key})")
-                for (i, slot) in enumerate(self.outputs)
+                slot.widget() for slot in self.outputs
             ]
 
+        label = ipywidgets.Label()
+        traitlets.link((self, "title"), (label, "value"))
         self.observe(_update_inputs, ["inputs"])
         self.observe(_update_outputs, ["outputs"])
         input_box = ipywidgets.VBox([ipywidgets.Label("Inputs")])
         output_box = ipywidgets.VBox([ipywidgets.Label("Outputs")])
-        return ipywidgets.VBox([ipywidgets.Label(self.title), input_box, output_box])
+        return ipywidgets.VBox([label, input_box, output_box])
 
 
 @ipywidgets.register

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -437,6 +437,15 @@ export class ReteEditorView extends DOMWidgetView {
     this.editor.on(['nodecreated'], async (node: Rete.Node) =>
       this.createNewNode(node)
     );
+    this.editor.on(
+      ['connectioncreated', 'connectionremoved'],
+      // Note that I *believe* that the connectionremoved function is called
+      // whenever a connection is clicked on.  That's not super ideal, since
+      // we really only want to sync when the connection has been deleted.
+      // We may actually eventually want to explore using connectiondrop, which
+      // may fire only when the mouse is lifted.
+      async (connection: Rete.Connection) => this.updateConnection(connection)
+    );
     this.editor.view.resize();
     this.addNewComponent();
   }
@@ -460,6 +469,10 @@ export class ReteEditorView extends DOMWidgetView {
       }
       console.log(newNode._node);
     }
+  }
+
+  async updateConnection(connection: Rete.Connection): Promise<void> {
+    console.log('Updated ', connection);
   }
 
   async createNewNode(node: Rete.Node): Promise<void> {


### PR DESCRIPTION
This adds connections mirrored between front and back end, and also makes nodes show up in multiple views of the same editor.  Some visual glitches as a result of moving nodes around which may be fixable.
