### PR TITLE
add a widget attribute to OutputSlot

### DIFF
--- a/jupyterlab_nodeeditor/node_editor.py
+++ b/jupyterlab_nodeeditor/node_editor.py
@@ -64,6 +64,11 @@ class OutputSlot(ipywidgets.Widget):
         sync=True, **ipywidgets.widget_serialization
     )
 
+    def _ipython_display_(self):
+        display(self.widget())
+
+    def widget(self):
+        return ipywidgets.Label(f"Slot {self.key}: {self.title} ({self.socket_type})")
 
 class OutputSlotTrait(traitlets.TraitType):
     default_value = None


### PR DESCRIPTION
While experimenting with `jupyterlab_nodeeditor/ygg_support.ipynb` I was getting the following attribute error in the jupyterlab log:

![Screenshot from 2022-08-31 15-31-21](https://user-images.githubusercontent.com/22038879/187776377-c9dbbcaf-2f60-4f80-8dbb-44323ff4e30a.png)

I copied over the `widget` attribute from `InputSlot` and it fixed the error.