### PR TITLE
Update node views as nodes are translated

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -364,6 +364,11 @@ export class ReteEditorModel extends DOMWidgetModel {
     for (const viewId of Object.keys(this.views)) {
       await this.views[viewId].then(v => {
         (v as ReteEditorView).editor.view.area.update();
+        for (const [node, nodeView] of (v as ReteEditorView).editor.view
+          .nodes) {
+          node.update();
+          nodeView.update();
+        }
       });
     }
   }
@@ -457,6 +462,9 @@ export class ReteEditorView extends DOMWidgetView {
     this.editor.use(ConnectionPlugin);
     this.editor.use(ContextMenuPlugin);
     this.editor.register(defaultComponent);
+    this.editor.on(['nodetranslated'], async () => {
+      this.model.updateViews();
+    });
     this.editor.on(['noderemoved'], async () => {
       this.model.updateViews();
     });

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -362,10 +362,10 @@ export class ReteEditorModel extends DOMWidgetModel {
 
   async updateViews(): Promise<void> {
     for (const viewId of Object.keys(this.views)) {
-      await this.views[viewId].then(v => {
-        (v as ReteEditorView).editor.view.area.update();
-        for (const [node, nodeView] of (v as ReteEditorView).editor.view
-          .nodes) {
+      await this.views[viewId].then(_v => {
+        const v = _v as ReteEditorView;
+        v.editor.view.area.update();
+        for (const [node, nodeView] of v.editor.view.nodes) {
           node.update();
           nodeView.update();
         }


### PR DESCRIPTION
Multiple editors will now stay in sync with where nodes are positioned.
