### PR TITLE
Mirror inputslots and outputslots

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -743,6 +743,7 @@ export class ReteEditorView extends DOMWidgetView {
     node.meta.nodeModel = newNode;
     newNode.set('inputs', node.meta.inputSlots);
     newNode.set('outputs', node.meta.outputSlots);
+    newNode.set('controls', node.meta.controls);
     newNode.save();
     const newNodes: ReteNodeModel[] = (
       this.model.get('nodes') as ReteNodeModel[]

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -741,6 +741,9 @@ export class ReteEditorView extends DOMWidgetView {
     )) as ReteNodeModel;
     newNode._node = node;
     node.meta.nodeModel = newNode;
+    newNode.set('inputs', node.meta.inputSlots);
+    newNode.set('outputs', node.meta.outputSlots);
+    newNode.save();
     const newNodes: ReteNodeModel[] = (
       this.model.get('nodes') as ReteNodeModel[]
     ).concat([newNode]);


### PR DESCRIPTION
This should allow nodes created in the frontend to show up in Python correctly.
